### PR TITLE
Bugfix/youtube video model description

### DIFF
--- a/lib/model/youtube_video_model.dart
+++ b/lib/model/youtube_video_model.dart
@@ -32,7 +32,7 @@ class YoutubeVideo {
     views = int.tryParse(json['viewCount']);
     channelID = json['channelId'];
     author = json['author'].toString().replaceAll('+', ' ');
-    description = json['viewCount'];
+    description = json['shortDescription'].toString().replaceAll('+', ' ');
     tags = json['keywords'].toString().replaceAll('+', ' ');
     thubmnail = json['thumbnail']['thumbnails'][4]['url'].toString();
     rating = json['averageRating'];


### PR DESCRIPTION
Fixes the deserialization of description for YoutubeVideo model. The key `viewCount` was used, however it should be `shortDescription`.